### PR TITLE
Log compiled configuration before starting dnsmasq

### DIFF
--- a/envreplace.sh
+++ b/envreplace.sh
@@ -45,7 +45,7 @@ fi
 
 echo "Compiled Configuration:"
 echo "===================="
-cat /etc/dnsmasq.conf
+cat -n /etc/dnsmasq.conf
 echo "===================="
 
 dnsmasq "$@"

--- a/envreplace.sh
+++ b/envreplace.sh
@@ -43,5 +43,10 @@ if [ "$1" = "--export" ]; then
   exit 0
 fi
 
+echo "Compiled Configuration:"
+echo "===================="
+cat /etc/dnsmasq.conf
+echo "===================="
+
 dnsmasq "$@"
 


### PR DESCRIPTION
Allows quick for fast paced debugging based on the docker log.

Right now the log provides the error location e.g. `dnsmasq: bad option at line 9 of /etc/dnsmasq.conf`
But without knowing the effectively used configuration it can be quite hard to backtrack mistakes made in setting the ENV variables.