### PR TITLE
Dump config optionally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ aliases:
           
           # get dnsmasq version
           if [ "$TAG" != "latest" ]; then
-            docker run --rm -t $IMAGE:$TAG --version
             DNSMASQ_VERSION="$(docker run --rm -t $IMAGE:$TAG --version |head -n1 |sed -e 's/Dnsmasq version \([0-9.]*\) *Copyright.*/\1/')"
             export TAG="$DNSMASQ_VERSION";
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,8 @@ aliases:
           
           # get dnsmasq version
           if [ "$TAG" != "latest" ]; then
-            DNSMASQ_VERSION="$(docker run --rm -it $IMAGE:$TAG --version |head -n1 |sed -e 's/Dnsmasq version \([0-9.]*\) *Copyright.*/\1/')"
+            docker run --rm -t $IMAGE:$TAG --version
+            DNSMASQ_VERSION="$(docker run --rm -t $IMAGE:$TAG --version |head -n1 |sed -e 's/Dnsmasq version \([0-9.]*\) *Copyright.*/\1/')"
             export TAG="$DNSMASQ_VERSION";
           fi
           

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,13 @@ aliases:
           docker buildx build --progress plain --platform linux/amd64 \
             --build-arg ALPINE_VERSION=<< parameters.alpine_version >> \
             --tag $IMAGE:$TAG --load .
+          docker image ls
           
           # get dnsmasq version
-          if [ "$TAG" != "latest" ]; then 
+          if [ "$TAG" != "latest" ]; then
+            docker run --rm -it $IMAGE:$TAG --version
             DNSMASQ_VERSION="$(docker run --rm -it $IMAGE:$TAG --version |head -n1 |sed -e 's/Dnsmasq version \([0-9.]*\) *Copyright.*/\1/')"
-            export TAG="$DNSMASQ_VERSION"; 
+            export TAG="$DNSMASQ_VERSION";
           fi
           
           # login, build & push : master or "-dev"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,9 @@ aliases:
           docker buildx build --progress plain --platform linux/amd64 \
             --build-arg ALPINE_VERSION=<< parameters.alpine_version >> \
             --tag $IMAGE:$TAG --load .
-          docker image ls
           
           # get dnsmasq version
           if [ "$TAG" != "latest" ]; then
-            docker run --rm -it $IMAGE:$TAG --version
             DNSMASQ_VERSION="$(docker run --rm -it $IMAGE:$TAG --version |head -n1 |sed -e 's/Dnsmasq version \([0-9.]*\) *Copyright.*/\1/')"
             export TAG="$DNSMASQ_VERSION";
           fi

--- a/envreplace.sh
+++ b/envreplace.sh
@@ -43,10 +43,12 @@ if [ "$1" = "--export" ]; then
   exit 0
 fi
 
-echo "Compiled Configuration:"
-echo "===================="
-cat -n /etc/dnsmasq.conf
-echo "===================="
+if [ -n "$CONFIG_DEBUG" ]; then
+  echo "Compiled Configuration:"
+  echo "===================="
+  cat -n /etc/dnsmasq.conf
+  echo "===================="
+fi
 
 dnsmasq "$@"
 


### PR DESCRIPTION
closes #19
introduced by #18

The code in the CI does not expect a printed config. In order to support both cases it's off by default and printed when `CONFIG_DEBUG` is set.