### PR TITLE
Make dnsmasq process the container's root process

### DIFF
--- a/envreplace.sh
+++ b/envreplace.sh
@@ -50,5 +50,5 @@ if [ -n "$CONFIG_DEBUG" ]; then
   echo "===================="
 fi
 
-dnsmasq "$@"
+exec dnsmasq "$@"
 


### PR DESCRIPTION
By using exec we can promote the dnsmasq process to be the root process of the container. This has the advantage that dnsmasq responds to the SIGTERM signal which makes the container stop instantly when using `docker stop`.

Alternatively, we could install a signal handler but I don't see a disadvantage to make the dnsmasq process the root process of the container so I think this is the cleaner solution.