### PR TITLE
feat: support for VIP with keepalived

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 !healthcheck.sh
 !dnsmasq.conf.tmpl
 !default.env
+!keepalived.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ALPINE_VERSION=edge
 FROM alpine:$ALPINE_VERSION
-RUN apk --no-cache add dnsmasq
+RUN apk --no-cache add dnsmasq keepalived
 
 COPY envreplace.sh dnsmasq.conf.tmpl healthcheck.sh default.env /
 RUN chmod +x /envreplace.sh /healthcheck.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:$ALPINE_VERSION
 RUN apk --no-cache add dnsmasq keepalived
 
 COPY envreplace.sh dnsmasq.conf.tmpl healthcheck.sh default.env /
+COPY keepalived.conf /etc/keepalived/keepalived.conf
 RUN chmod +x /envreplace.sh /healthcheck.sh
 
 EXPOSE 53 53/udp 67/udp

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Make sure to use the VIP (`192.168.1.250` in this example) as DNS and DHCP liste
 
 ```shell
 # make sure to set the DNS and DHCP listen address to the VIP (DMQ_DHCP_DNS, DMQ_GLOBAL_LISTEN)
+echo "DMQ_GLOBAL_BIND=bind-dynamic" >> dnsmasq.env
 echo "DMQ_GLOBAL_LISTEN=listen-address=127.0.0.1,192.168.1.250" >> dnsmasq.env
 echo "DMQ_DHCP_DNS=dhcp-option=6,192.168.1.250,8.8.8.8,8.8.4.4" >> dnsmasq.env
 echo "KEEPALIVE_STATE=MASTER" >> dnsmasq.env
@@ -154,6 +155,7 @@ echo "KEEPALIVE_VIP=192.168.1.250" >> dnsmasq.env
 docker run ... # see above
 
 # for the backup, similarly with lower priority:
+echo "DMQ_GLOBAL_BIND=bind-dynamic" >> dnsmasq.env
 echo "DMQ_GLOBAL_LISTEN=listen-address=127.0.0.1,192.168.1.250" >> dnsmasq.env
 echo "DMQ_DHCP_DNS=dhcp-option=6,192.168.1.250,8.8.8.8,8.8.4.4" >> dnsmasq.env
 echo "KEEPALIVE_STATE=BACKUP" >> dnsmasq.env

--- a/README.md
+++ b/README.md
@@ -134,10 +134,12 @@ docker run ... --publish 192.168.1.253:53:53 ... (for every port)
 
 ## Failover with `keepalived`
 
-Setup two containers, each with an individual IP. Configure an additional VIP for `keepalived` and define which container
-is the master and which one is the backup.
+Setup two containers (on different hosts), each with an individual IP. Configure an additional VIP for `keepalived` and define which container
+is the master and which one is the backup. When the master fails, or you run docker updates etc, the backup will kick in
+and bring up the VIP and announce it in the network. Once the master is back up, it will take over again as it has a higher
+priority.
 
-Make sure to use the VIP as DNS and DHCP listen address for `dnsmasq`.
+Make sure to use the VIP (`192.168.1.250` in this example) as DNS and DHCP listen address for `dnsmasq`.
 
 ```shell
 # make sure to set the DNS and DHCP listen address to the VIP (DMQ_DHCP_DNS, DMQ_GLOBAL_LISTEN)
@@ -146,7 +148,7 @@ echo "DMQ_DHCP_DNS=dhcp-option=6,192.168.1.250,8.8.8.8,8.8.4.4" >> dnsmasq.env
 echo "KEEPALIVE_STATE=MASTER" >> dnsmasq.env
 echo "KEEPALIVE_PRIO=100" >> dnsmasq.env
 echo "KEEPALIVE_ID=21" >> dnsmasq.env
-echo "KEEPALIVE_PASS=S3cr3t" >> dnsmasq.env
+echo "KEEPALIVE_PASS=S3cr3t99" >> dnsmasq.env
 echo "KEEPALIVE_VIP=192.168.1.250" >> dnsmasq.env 
 
 docker run ... # see above
@@ -157,12 +159,13 @@ echo "DMQ_DHCP_DNS=dhcp-option=6,192.168.1.250,8.8.8.8,8.8.4.4" >> dnsmasq.env
 echo "KEEPALIVE_STATE=BACKUP" >> dnsmasq.env
 echo "KEEPALIVE_PRIO=99" >> dnsmasq.env
 echo "KEEPALIVE_ID=21" >> dnsmasq.env
-echo "KEEPALIVE_PASS=S3cr3t" >> dnsmasq.env
+echo "KEEPALIVE_PASS=S3cr3t99" >> dnsmasq.env
 echo "KEEPALIVE_VIP=192.168.1.250" >> dnsmasq.env
 
 docker run ... # see above
 ```
 
+Keepalived User Guide: https://readthedocs.org/projects/keepalived-pqa/downloads/pdf/latest/
 
 # Credits
 Automated build inspired by

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Purpose:
 * use one image to run them all
 * run stateless, environment configured containers (see https://12factor.net/)
 * use primarily to setup DNS/DHCP for simple/home environments
+* **new**: support for VIP with `keepalived` (see below)
 
 ## Usage
 
@@ -130,6 +131,38 @@ Try this:
 sudo ip addr add 192.168.1.253/32 dev eth1
 docker run ... --publish 192.168.1.253:53:53 ... (for every port)
 ```
+
+## Failover with `keepalived`
+
+Setup two containers, each with an individual IP. Configure an additional VIP for `keepalived` and define which container
+is the master and which one is the backup.
+
+Make sure to use the VIP as DNS and DHCP listen address for `dnsmasq`.
+
+```shell
+# make sure to set the DNS and DHCP listen address to the VIP (DMQ_DHCP_DNS, DMQ_GLOBAL_LISTEN)
+echo "DMQ_GLOBAL_LISTEN=listen-address=127.0.0.1,192.168.1.250" >> dnsmasq.env
+echo "DMQ_DHCP_DNS=dhcp-option=6,192.168.1.250,8.8.8.8,8.8.4.4" >> dnsmasq.env
+echo "KEEPALIVE_STATE=MASTER" >> dnsmasq.env
+echo "KEEPALIVE_PRIO=100" >> dnsmasq.env
+echo "KEEPALIVE_ID=21" >> dnsmasq.env
+echo "KEEPALIVE_PASS=S3cr3t" >> dnsmasq.env
+echo "KEEPALIVE_VIP=192.168.1.250" >> dnsmasq.env 
+
+docker run ... # see above
+
+# for the backup, similarly with lower priority:
+echo "DMQ_GLOBAL_LISTEN=listen-address=127.0.0.1,192.168.1.250" >> dnsmasq.env
+echo "DMQ_DHCP_DNS=dhcp-option=6,192.168.1.250,8.8.8.8,8.8.4.4" >> dnsmasq.env
+echo "KEEPALIVE_STATE=BACKUP" >> dnsmasq.env
+echo "KEEPALIVE_PRIO=99" >> dnsmasq.env
+echo "KEEPALIVE_ID=21" >> dnsmasq.env
+echo "KEEPALIVE_PASS=S3cr3t" >> dnsmasq.env
+echo "KEEPALIVE_VIP=192.168.1.250" >> dnsmasq.env
+
+docker run ... # see above
+```
+
 
 # Credits
 Automated build inspired by

--- a/dnsmasq.conf.tmpl
+++ b/dnsmasq.conf.tmpl
@@ -1,4 +1,9 @@
-echo -e "$DMQ_GLOBAL"
+echo "### DMQ_GLOBAL*"
+for v in $(set | grep ^DMQ_GLOBAL| sed -e 's/^\(DMQ_GLOBAL[^=]*\).*/\1/' | sort -r | tr '\n', ' '); do
+  val=$(eval echo "\$$v")
+  [ -z "$v" -o -z "$val" ] && continue
+  echo -e "$val"
+done
 echo
 echo "### DMQ_DNS*"
 for v in $(set | grep ^DMQ_DNS| sed -e 's/^\(DMQ_DNS[^=]*\).*/\1/' | sort -r | tr '\n', ' '); do

--- a/envreplace.sh
+++ b/envreplace.sh
@@ -50,5 +50,15 @@ if [ -n "$CONFIG_DEBUG" ]; then
   echo "===================="
 fi
 
+if [ -n "$KEEPALIVE_STATE" ]; then
+  echo "Enabling keepalived"
+  KEEPALIVE_PRIO=${KEEPALIVE_PRIO:-100}
+  KEEPALIVE_ID=${KEEPALIVE_ID:-21}
+  sed -i -e "s/KEEPALIVE_STATE/$KEEPALIVE_STATE/" -e "s/KEEPALIVE_PRIO/$KEEPALIVE_PRIO/" \
+    -e "s/KEEPALIVE_PASS/$KEEPALIVE_PASS/" -e "s/KEEPALIVE_VIP/$KEEPALIVE_VIP/" \
+    -e "s/KEEPALIVE_ID/$KEEPALIVE_ID/" /etc/keepalived/keepalived.conf
+  keepalived -P -l &
+fi
+
 exec dnsmasq "$@"
 

--- a/envreplace.sh
+++ b/envreplace.sh
@@ -57,7 +57,7 @@ if [ -n "$KEEPALIVE_STATE" ]; then
   sed -i -e "s/KEEPALIVE_STATE/$KEEPALIVE_STATE/" -e "s/KEEPALIVE_PRIO/$KEEPALIVE_PRIO/" \
     -e "s/KEEPALIVE_PASS/$KEEPALIVE_PASS/" -e "s/KEEPALIVE_VIP/$KEEPALIVE_VIP/" \
     -e "s/KEEPALIVE_ID/$KEEPALIVE_ID/" /etc/keepalived/keepalived.conf
-  keepalived -P -n -D -l 2>&1 > /dev/stdout &
+  keepalived -P -n -l 2>&1 > /dev/stdout &
 fi
 
 exec dnsmasq "$@"

--- a/envreplace.sh
+++ b/envreplace.sh
@@ -57,6 +57,12 @@ if [ -n "$KEEPALIVE_STATE" ]; then
   sed -i -e "s/KEEPALIVE_STATE/$KEEPALIVE_STATE/" -e "s/KEEPALIVE_PRIO/$KEEPALIVE_PRIO/" \
     -e "s/KEEPALIVE_PASS/$KEEPALIVE_PASS/" -e "s/KEEPALIVE_VIP/$KEEPALIVE_VIP/" \
     -e "s/KEEPALIVE_ID/$KEEPALIVE_ID/" /etc/keepalived/keepalived.conf
+
+  if [ -n "$(grep bind-dynamic /etc/dnsmasq.conf)" ]; then
+    echo "WARNING: 'bind-dynamic' should be enabled when using keeplived, so that dnsmasq binds to the VIP dynamically."
+  fi
+
+  rm -f /run/keepalived/*.pid
   keepalived -P -n -l 2>&1 > /dev/stdout &
 fi
 

--- a/envreplace.sh
+++ b/envreplace.sh
@@ -57,7 +57,7 @@ if [ -n "$KEEPALIVE_STATE" ]; then
   sed -i -e "s/KEEPALIVE_STATE/$KEEPALIVE_STATE/" -e "s/KEEPALIVE_PRIO/$KEEPALIVE_PRIO/" \
     -e "s/KEEPALIVE_PASS/$KEEPALIVE_PASS/" -e "s/KEEPALIVE_VIP/$KEEPALIVE_VIP/" \
     -e "s/KEEPALIVE_ID/$KEEPALIVE_ID/" /etc/keepalived/keepalived.conf
-  keepalived -P -l
+  keepalived -P -n -D -l 2>&1 > /dev/stdout &
 fi
 
 exec dnsmasq "$@"

--- a/envreplace.sh
+++ b/envreplace.sh
@@ -57,7 +57,7 @@ if [ -n "$KEEPALIVE_STATE" ]; then
   sed -i -e "s/KEEPALIVE_STATE/$KEEPALIVE_STATE/" -e "s/KEEPALIVE_PRIO/$KEEPALIVE_PRIO/" \
     -e "s/KEEPALIVE_PASS/$KEEPALIVE_PASS/" -e "s/KEEPALIVE_VIP/$KEEPALIVE_VIP/" \
     -e "s/KEEPALIVE_ID/$KEEPALIVE_ID/" /etc/keepalived/keepalived.conf
-  keepalived -P -l &
+  keepalived -P -l
 fi
 
 exec dnsmasq "$@"

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
 
-if [ -z "$(ps |grep [d]nsmasq)" ]; then
+if [ -z "$(pgrep dnsmasq)" ]; then
   echo "no 'dnsmasq' process found!"
   exit 1
 fi
 
 if [ -z "$(netstat -nltu |grep \:53)" ]; then
   echo "no process listening on port 53!"
+  exit 1
+fi
+
+if [ -n "$KEEPALIVE_STATE" -a -z "$(pgrep keepalived)" ]; then
+  echo "keepalived configured but not running!"
   exit 1
 fi

--- a/keepalived.conf
+++ b/keepalived.conf
@@ -1,3 +1,7 @@
+global_defs {
+        # according to logs, setting this improves performance?
+        max_auto_priority 10
+}
 vrrp_instance dnsmasq {
         state KEEPALIVE_STATE
         interface eth0

--- a/keepalived.conf
+++ b/keepalived.conf
@@ -1,0 +1,14 @@
+vrrp_instance dnsmasq {
+        state KEEPALIVE_STATE
+        interface eth0
+        virtual_router_id KEEPALIVE_ID
+        priority KEEPALIVE_PRIO
+        advert_int 1
+        authentication {
+              auth_type PASS
+              auth_pass KEEPALIVE_PASS
+        }
+        virtual_ipaddress {
+              KEEPALIVE_VIP
+        }
+}


### PR DESCRIPTION
Purpose:
Cheap way to have a "High availability" setup of DNS/DHCP with `dnsmasq`

Idea:
- two `dnsmasq` container instances, each with an individual IP
- a shared VIP controlled through `keepalived` which is used for DNS/DHCP
- if the master fails, the backup takes over the VIP and serves DNS/DHCP requests

Know issues:
- DHCP leases file is not shared, so clients will get a new lease (might cause a short connectivity interruption)
- Communication to/from the host to the container through macvlan is not possible out of the box (has been the case before as well). This post might help: https://blog.oddbit.com/post/2018-03-12-using-docker-macvlan-networks/#host-access

Further reading on scripts for keepalived: https://tobrunet.ch/keepalived-check-and-notify-scripts/