### PR TITLE
feat: add support for KEEPALIVE_INTERFACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ docker run ... # see above
 
 Keepalived User Guide: https://readthedocs.org/projects/keepalived-pqa/downloads/pdf/latest/
 
+### supported `keepalived` environment variables
+|name|description|comment|required/optional|potential values|default|
+|---|---|---|---|---|---|
+|`KEEPALIVE_ID`|virtual router id|keep the same for all members of the keepalived group|optional|numeric|`21`|
+|`KEEPALIVE_INTERFACE`|network interface|the name of the nic keepalived should listen on|optional|string|`eth0`|
+|`KEEPALIVE_PASS`|password|keep the same for all the members of the keepalived group|optional|string|`S3cr3t99`|
+|`KEEPALIVE_PRIO`|priority|this characterises which member of the group should be active, if the `MASTER` member is unavailable|optional|numeric|`100`|
+|`KEEPALIVE_STATE`|state|this characterises the member as either `MASTER` or `BACKUP`.|**required**|`MASTER`\|`BACKUP`|_none_|
+|`KEEPALIVE_VIP`|virtual ip address|the ip address to be shared for all members of the keepalived group|**required**|ip address|_none_|
+
+
 # Credits
 Automated build inspired by
 * https://medium.com/vaidikkapoor/managing-open-source-docker-images-on-docker-hub-using-travis-7fd33bc96d65

--- a/envreplace.sh
+++ b/envreplace.sh
@@ -54,9 +54,10 @@ if [ -n "$KEEPALIVE_STATE" ]; then
   echo "Enabling keepalived"
   KEEPALIVE_PRIO=${KEEPALIVE_PRIO:-100}
   KEEPALIVE_ID=${KEEPALIVE_ID:-21}
+  KEEPALIVE_INTERFACE=${KEEPALIVE_INTERFACE:-eth0}
   sed -i -e "s/KEEPALIVE_STATE/$KEEPALIVE_STATE/" -e "s/KEEPALIVE_PRIO/$KEEPALIVE_PRIO/" \
     -e "s/KEEPALIVE_PASS/$KEEPALIVE_PASS/" -e "s/KEEPALIVE_VIP/$KEEPALIVE_VIP/" \
-    -e "s/KEEPALIVE_ID/$KEEPALIVE_ID/" /etc/keepalived/keepalived.conf
+    -e "s/KEEPALIVE_ID/$KEEPALIVE_ID/" -e "s/KEEPALIVE_INTERFACE/$KEEPALIVE_INTERFACE/" /etc/keepalived/keepalived.conf
 
   if [ -z "$(grep bind-dynamic /etc/dnsmasq.conf)" ]; then
     echo "WARNING: 'bind-dynamic' should be enabled when using keeplived, so that dnsmasq binds to the VIP dynamically."

--- a/keepalived.conf
+++ b/keepalived.conf
@@ -4,7 +4,7 @@ global_defs {
 }
 vrrp_instance dnsmasq {
         state KEEPALIVE_STATE
-        interface eth0
+        interface KEEPALIVE_INTERFACE
         virtual_router_id KEEPALIVE_ID
         priority KEEPALIVE_PRIO
         advert_int 1


### PR DESCRIPTION
_support interfaces with names other than eth0_

This pull request introduces new environment variables to the `keepalived` configuration and updates the relevant documentation and scripts to support these changes. The most important changes include adding a new section to the `README.md` file for the supported `keepalived` environment variables, updating the `envreplace.sh` script to include the new `KEEPALIVE_INTERFACE` variable, and modifying the `keepalived.conf` file to use the new variable.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R182): Added a new section to document the supported `keepalived` environment variables, including descriptions, comments, and default values.

Script updates:

* [`envreplace.sh`](diffhunk://#diff-591ebbf5157e1d918a34613abed39831a6b3dd610058787b1a7a81aa3a82cb9dR57-R60): Added support for the `KEEPALIVE_INTERFACE` environment variable and updated the `sed` command to replace this variable in the `keepalived.conf` file.

Configuration updates:

* [`keepalived.conf`](diffhunk://#diff-fe3f8a907cc707156a7cdf989267eb1310286b1c48c9ff3e71d190c11f40e525L7-R7): Replaced the hardcoded network interface with the `KEEPALIVE_INTERFACE` variable to allow dynamic configuration.